### PR TITLE
Removed space between images and card edges

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -519,12 +519,10 @@ footer {
   margin-top: 20px;
   margin-bottom: 20px;
   background-color: linen;
+  padding: 0px;
+  padding-bottom: 10px;
   border: solid 1px;
   border-color: rgb(136, 132, 132);
-}
-
-.card-body {
-  padding: 10px;
 }
 
 .card-text {
@@ -539,7 +537,10 @@ footer {
 }
 
 .menu-btn-div {
-  align-self: flex-end;
+  position: relative;
+  width: 80%;
+  margin-left: 10%;
+  margin-right: 10%;
 }
 
 .card-button:hover {
@@ -552,6 +553,8 @@ footer {
   width: 100%;
   height: 220px;
   border-radius: 0.25rem;
+  border-bottom-left-radius: 0px;
+  border-bottom-right-radius: 0px;
 }
 
 .card:hover {


### PR DESCRIPTION
# What Changes were Made?
* I set the padding in the `.card` div to 0px
* I set the border radius at the bottom left and right to 0 for the card image


# Why were the Changes Made?
* This is to make the image look like it is part of the upper area of the card which gives it a more cohesive appearance.

# Improvements
* The changes made to the padding bottom for the card, removal of the `.card-body` div and all the changes to the button in the card  were done to get the button to align to the bottom of the card with a bit of space in between. This should be changed to make sure that the desired effect is achieved.
