### PR TITLE
Redid cards in location page with vanilla CSS

### DIFF
--- a/pages/locations.html
+++ b/pages/locations.html
@@ -105,90 +105,135 @@
     </div>
   </nav>
 
-  <h1>Where to Find Us</h1>
-
-  <!-- Maps -->
 
 
-  <div class="container">
 
-    <!-- South Beach -->
-    <div class="row d-flex flex-row location-jumbos">
-      <div class="card col-sm-7 col-md-7 col-lg-4 mx-auto">
-        <img
-          src="https://images.unsplash.com/photo-1543414888-33c11c507629?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTR8fHNvdXRoJTIwYmVhY2glMjBkdXJiYW58ZW58MHx8MHx8&auto=format&fit=crop&w=500&q=60"
-          class="card-imgs" alt="...">
-        <div class="card-body">
-          <h5 class="card-title">South Beach</h5>
-          <p class="card-text">
-            1 Erskine Terrace, South Beach, Durban, 4001
-          </p>
+
+  <main>
+
+    <h1>Where to Find Us</h1>
+
+
+    <div class="container">
+
+      <!-- South Beach -->
+      <div class="location-jumbos">
+        <div class="location-card">
+          <img
+            src="https://images.unsplash.com/photo-1543414888-33c11c507629?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTR8fHNvdXRoJTIwYmVhY2glMjBkdXJiYW58ZW58MHx8MHx8&auto=format&fit=crop&w=500&q=60"
+            class="location-imgs" alt="...">
+          <div class="location-card-body">
+            <h5 class="location-card-title">South Beach</h5>
+            <p class="card-text">
+              1 Erskine Terrace, South Beach, Durban, 4001
+            </p>
+
+            <h5 class="location-card-title">Trading Hours</h5>
+            <p class="card-text">
+              Sun - Thur: 07:00 - 18:00
+            </p>
+            <p class="card-text">
+              Fri - Sat: 07:00 - 20:00
+            </p>
+
+            <h5 class="location-card-title">Contact Number</h5>
+            <p class="card-text">
+              031-xxx-xxxx
+            </p>
+          </div>
+        </div>
+
+        <div class="map-card">
+          <iframe
+            src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3459.9501785146913!2d31.041756314757187!3d-29.86571062994582!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x1ef7a85011363ced%3A0x385c87e29f0d6ffe!2s1%20Erskine%20Terrace%2C%20Point%2C%20Durban%2C%204001!5e0!3m2!1sen!2sza!4v1645235261455!5m2!1sen!2sza"
+            style="border:0;" allowfullscreen="" loading="lazy" class="map"></iframe>
         </div>
       </div>
-
-      <div class="col-sm-7 col-md-7 col-lg-4 mx-auto">
-        <iframe
-          src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3459.9501785146913!2d31.041756314757187!3d-29.86571062994582!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x1ef7a85011363ced%3A0x385c87e29f0d6ffe!2s1%20Erskine%20Terrace%2C%20Point%2C%20Durban%2C%204001!5e0!3m2!1sen!2sza!4v1645235261455!5m2!1sen!2sza"
-          style="border:0;" allowfullscreen="" loading="lazy" class="map"></iframe>
-      </div>
-    </div>
-    <!-- South Beach -->
+      <!-- South Beach -->
 
 
 
 
 
-    <!-- Umhlanga -->
-    <div class="row d-flex flex-row location-jumbos reveal">
-      <div class="card col-sm-7 col-md-7 col-lg-4 mx-auto">
-        <img
-          src="https://media.istockphoto.com/photos/umhlanga-lighthouse-one-of-the-worlds-iconic-lighthouses-in-durban-picture-id1336188234?b=1&k=20&m=1336188234&s=170667a&w=0&h=cyE2qSRNVS4TglfBEt41Ty2DkFNRoyfHJSvuw1DEH5M="
-          class="card-imgs" alt="...">
-        <div class="card-body">
-          <h5 class="card-title">Umhlanga</h5>
-          <p class="card-text">
-            10 Lagoon Dr, Umhlanga, 4320
-          </p>
+      <!-- Umhlanga -->
+      <div class="location-jumbos reveal">
+        <div class="location-card">
+          <img
+            src="https://media.istockphoto.com/photos/umhlanga-lighthouse-one-of-the-worlds-iconic-lighthouses-in-durban-picture-id1336188234?b=1&k=20&m=1336188234&s=170667a&w=0&h=cyE2qSRNVS4TglfBEt41Ty2DkFNRoyfHJSvuw1DEH5M="
+            class="location-imgs" alt="...">
+          <div class="location-card-body">
+            <h5 class="location-card-title">Umhlanga</h5>
+            <p class="card-text">
+              10 Lagoon Dr, Umhlanga, 4320
+            </p>
+
+            <h5 class="location-card-title">Trading Hours</h5>
+            <p class="card-text">
+              Sun - Thur: 09:00 - 19:00
+            </p>
+            <p class="card-text">
+              Fri - Sat: 09:00 - 23:00
+            </p>
+
+            <h5 class="location-card-title">Contact Number</h5>
+            <p class="card-text">
+              031-xxx-xxxx
+            </p>
+          </div>
+        </div>
+
+        <div class="map-card">
+          <iframe
+            src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3464.8648138331623!2d31.086965214752734!3d-29.72367492339053!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x1ef70f5b6bdf5e13%3A0x5c1939f96dc6bc90!2s10%20Lagoon%20Dr%2C%20Umhlanga%2C%204320!5e0!3m2!1sen!2sza!4v1645235150590!5m2!1sen!2sza"
+            style="border:0;" allowfullscreen="" loading="lazy" class="map"></iframe>
         </div>
       </div>
-
-      <div class="col-sm-7 col-md-7 col-lg-4 mx-auto">
-        <iframe
-          src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3464.8648138331623!2d31.086965214752734!3d-29.72367492339053!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x1ef70f5b6bdf5e13%3A0x5c1939f96dc6bc90!2s10%20Lagoon%20Dr%2C%20Umhlanga%2C%204320!5e0!3m2!1sen!2sza!4v1645235150590!5m2!1sen!2sza"
-          style="border:0;" allowfullscreen="" loading="lazy" class="map"></iframe>
-      </div>
-    </div>
-    <!-- Umhlanga -->
+      <!-- Umhlanga -->
 
 
 
 
 
-    <!-- Westville -->
-    <div class="row d-flex flex-row location-jumbos reveal">
-      <div class="card col-sm-7 col-md-7 col-lg-4 mx-auto">
-        <img src="https://sncdn.com/imagecache/db/id/670709/go172409.jpg" class="card-imgs" alt="...">
-        <div class="card-body">
-          <h5 class="card-title">Westville</h5>
-          <p class="card-text">
-            Jack Martens Dr, Dawncliffe, Westville, 3611
-          </p>
+      <!-- Westville -->
+      <div class="location-jumbos reveal">
+        <div class="location-card">
+          <img src="https://sncdn.com/imagecache/db/id/670709/go172409.jpg" class="location-imgs" alt="...">
+          <div class="location-card-body">
+            <h5 class="location-card-title">Westville</h5>
+            <p class="card-text">
+              Jack Martens Dr, Dawncliffe, Westville, 3611
+            </p>
+
+            <h5 class="location-card-title">Trading Hours</h5>
+            <p class="card-text">
+              Sun - Thur: 09:00 - 19:00
+            </p>
+            <p class="card-text">
+              Fri - Sat: 09:00 - 21:00
+            </p>
+
+            <h5 class="location-card-title">Contact Number</h5>
+            <p class="card-text">
+              031-xxx-xxxx
+            </p>
+          </div>
+        </div>
+
+        <div class="map-card">
+          <iframe
+            src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3460.4879850424954!2d30.933431114756658!3d-29.850197629228575!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x1ef70064a403f061%3A0x4f091f0993a4c9db!2s3611%20Jack%20Martens%20Dr%2C%20Dawncliffe%2C%20Durban%2C%203629!5e0!3m2!1sen!2sza!4v1645235214392!5m2!1sen!2sza"
+            style="border:0;" allowfullscreen="" loading="lazy" class="map"></iframe>
         </div>
       </div>
+      <!-- Westville -->
 
-      <div class="col-sm-7 col-md-7 col-lg-4 mx-auto">
-        <iframe
-          src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3460.4879850424954!2d30.933431114756658!3d-29.850197629228575!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x1ef70064a403f061%3A0x4f091f0993a4c9db!2s3611%20Jack%20Martens%20Dr%2C%20Dawncliffe%2C%20Durban%2C%203629!5e0!3m2!1sen!2sza!4v1645235214392!5m2!1sen!2sza"
-          style="border:0;" allowfullscreen="" loading="lazy" class="map"></iframe>
-      </div>
     </div>
-    <!-- Westville -->
-
-  </div>
 
 
-  <script src="/javascripts/reveal.js"></script>
-  
+
+  </main>
+
+
 
 
 

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -194,6 +194,9 @@ input[type="email"] {
 
 /* LOCATIONS */
 .location-jumbos {
+  display: flex;
+  justify-content: space-around;
+  height: 500px;
   margin-top: 50px;
   margin-bottom: 50px;
   padding: 10px;
@@ -211,12 +214,49 @@ input[type="email"] {
   border-radius: 0.3rem;
 }
 
+.location-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 40%;
+  height: 90%;
+  background: none;
+  border: none;
+  margin-top: 20px;
+  margin-bottom: 20px;
+  padding: 0px;
+  padding-bottom: 10px;
+}
+
+.location-imgs {
+    width: 55%;
+    height: 175px;
+    border-radius: 0.25rem;
+}
+
+.location-card-body {
+  margin-top: 15px;
+  border: none;
+}
+
+.location-card-title {
+  margin-top: 20px;
+  text-align: center;
+}
+
+.map-card {
+  margin-top: auto;
+  margin-bottom: auto;
+  padding: 0;
+  width: 45%;
+  height: 70%;
+}
+
 .map {
   justify-content: center;
   border-radius: 0.3rem;
-  margin-top: 18px;
-  width: 350px;
-  height: 340px;
+  width: 100%;
+  height: 100%;
 }
 
 .location-head {


### PR DESCRIPTION
# What Changes were Made?
* I moved all the content after the navbar into a `main` tag
* I removed all the bootstrap classes from the cards and renamed them to have more page related names and that includes the following:
  * The card class was renamed from `.card` to `.location-card`
  * The image class was renamed from `.card-img` to `.location-imgs`
  * The class for the heading in the cards were renamed from `.card-title` to `.location-card-title`
  * The div wrapped around the map was named `.map-card`
* I added new h5 and paragraph tags and paragraphs to each location cards and they include information about the two sets of trading times and the contact information for each location.
* The `.location-jumbos` was given a display of flex and then evenly spaced out the content. I also gave it a height of 500px
* The styles for the `.location-card` were taken from the `.card` class and then I removed the border and the background styling and added the following styles:
  * A display of flex
  * A flex-direction of column
  * An align-item of center
  * Height and width were set to 90% and 40% respectively
* The `.map-card` div was given a margin top and bottom of auto, padding of 0 and height and width of 100%


# Why were the Changes Made?
* The content which was moved into the main tag was moved there so it can be separated from the rest of the content and have its own specific container
* The renaming of the classes in the card were done so they can be separated from the cards which are in the menu page and have very different styling. This was also done to prevent any specificity problems which would arise from adding additional classes
* The changes made to the body of the `.location-card` with the title and paragraph tags were to add the additional information for each location and then organize the information vertically and make sure the content was centrally aligned 
